### PR TITLE
Updates for FileZilla_Server-0_9_54

### DIFF
--- a/FLACore.py
+++ b/FLACore.py
@@ -1174,7 +1174,9 @@ def analyze((m,p,d,t,u,i,a),lineCtr):
             print msg, lineCtr+1
     elif parsedAction[0] == '226' and ((parsedAction[1] == 'ABOR' and parsedAction[2] == 'command') or \
                                        (parsedAction[1] == 'Transfer' and (parsedAction[2] == 'OK' or \
-                                                                           parsedAction[2] == 'OK,'))):
+                                                                           parsedAction[2] == 'OK,')) or \
+                                       (parsedAction[1] == 'Successfully' and (parsedAction[2] == 'transferred' or \
+                                                                           parsedAction[2] == 'transferred,'))):
         tempM = G.events.getStored(m,u,p,True)
         if grabAfterUser(tempM,2) == 'began downloading' or grabAfterUser(tempM,2) == 'restarted download':
             msg = "User '" + u + "' finished downloading '" + G.events.getHeldStatistic(m,u,p)[5] + "'."

--- a/FLACore.py
+++ b/FLACore.py
@@ -1987,7 +1987,7 @@ def processAndExecute(argv,nextArg):
     discInst = None
 
     G.logFile = argv[nextArg]
-    f = open(G.logFile)
+    f = open(G.logFile, encoding="utf-8")
     lineCtr = 0
     G.line = 1
     if (G.pFlag and not G.sFlag and (G.parseFrom != -1 or G.parseTill != -1))  or (G.fFlag and G.specifiedLineNum == -1): 


### PR DESCRIPTION
fixed: No successful transfers were found as the text returned by FileZilla server changed for the "226" status code. (was "Transfer OK" now is "Successfully transferred")
fixed: By now FileZilla_Server (0_9_54) produces utf-8 log files. Decoding 
